### PR TITLE
Fixed SuperSpeed, KBInput, and added unlimited battery for the rescue hook and norg gun

### DIFF
--- a/SpookSuite/Cheats/Self/SuperSpeed.cs
+++ b/SpookSuite/Cheats/Self/SuperSpeed.cs
@@ -15,7 +15,7 @@ namespace SpookSuite.Cheats
 
         public override void OnDisable()
         {
-            Player.localPlayer.gameObject.GetComponent<PlayerController>().movementForce = 10f;
+            Player.localPlayer.gameObject.GetComponent<PlayerController>().movementForce = 17f;
         }
     }
 }

--- a/SpookSuite/Cheats/Self/UnlimitedBattery.cs
+++ b/SpookSuite/Cheats/Self/UnlimitedBattery.cs
@@ -1,4 +1,4 @@
-﻿using SpookSuite.Cheats.Core;
+using SpookSuite.Cheats.Core;
 using SpookSuite.Util;
 
 namespace SpookSuite.Cheats
@@ -22,6 +22,12 @@ namespace SpookSuite.Cheats
 
             if (item.GetComponent<ShockStick>() is not null)
                 battery = item.GetComponent<ShockStick>().Reflect().GetValue<BatteryEntry>("m_batteryEntry");
+
+            if (item.GetComponent<RescueHook>() is not null)
+                battery = item.GetComponent<RescueHook>().Reflect().GetValue<BatteryEntry>("m_batteryEntry");
+
+            if (item.GetComponent<NorgGun>() is not null)
+                battery = item.GetComponent<NorgGun>().Reflect().GetValue<BatteryEntry>("m_batteryEntry");
 
             if (item.GetComponent<PartyPopper>() is not null)
             {

--- a/SpookSuite/Components/KBInput.cs
+++ b/SpookSuite/Components/KBInput.cs
@@ -4,8 +4,8 @@ namespace SpookSuite.Components
 {
     internal class KBInput : MonoBehaviour
     {
-        public float sprintMultiplier = 2f;
-        public float movementSpeed = 10f;
+        public float sprintMultiplier = 2.3f;
+        public float movementSpeed = 17f;
 
         public Vector3 movement;
 


### PR DESCRIPTION
If you check with unity explorer, the default value of movementForce is actually 17 instead of 10, and the default value of sprintMultiplier is 2.3 instead of 2